### PR TITLE
refactor: update retry handling when another process installing packages

### DIFF
--- a/pkg/utils/osutils/osutils_test.go
+++ b/pkg/utils/osutils/osutils_test.go
@@ -123,6 +123,45 @@ func TestPackageManagerQuery(t *testing.T) {
 	}
 }
 
+func TestPackageManagerLock(t *testing.T) {
+	if testArch() != "linux" {
+		t.Skip("Skipping test on macOS since /proc does not exist")
+	}
+
+	got, err := PackageManagerLock()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if got {
+		t.Errorf("Expected PackageManagerLock to return false: Got: %v, Error: %v", got, err)
+	}
+}
+
+func TestIsLockFileInUse(t *testing.T) {
+	if testArch() != "linux" {
+		t.Skip("Skipping test on macOS since /proc does not exist")
+	}
+
+	got, err := isLockFileInUse("continue")
+	if err != nil {
+		t.Errorf("Expected error %v", err)
+	}
+
+	if got {
+		t.Errorf("Expected IsLockFileInUse to return false: Got: %v, Error: %v", got, err)
+	}
+
+	got, err = isLockFileInUse("/dev/null")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !got {
+		t.Errorf("Expected IsLockFileInUse to return true: Got: %v, Error: %v", got, err)
+	}
+}
+
 func TestSCQueryExists(t *testing.T) {
 	got, err := scQuery("csagent")
 	if err == nil {

--- a/pkg/utils/osutils/osutils_windows_test.go
+++ b/pkg/utils/osutils/osutils_windows_test.go
@@ -111,6 +111,17 @@ func TestReadEtcRelease(t *testing.T) {
 	}
 }
 
+func TestPackageManagerLock(t *testing.T) {
+	got, err := PackageManagerLock()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if got {
+		t.Errorf("Expected not to return a package lock: Got: %v, Error: %v", got, err)
+	}
+}
+
 func TestSCQuery(t *testing.T) {
 	scQueryCmnd = "sc.exe"
 	got, err := scQuery("csagent")


### PR DESCRIPTION
- change max retries to timeout after 10 minutes
- add support for rpm lock handling
- refactor to check /proc for lock on the rpm/dpkg lock file